### PR TITLE
Godoc spacing fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/README.markdown
+++ b/README.markdown
@@ -28,7 +28,7 @@ authorities, which this essentially is.)
 
 Install an official [tarball](http://golang.org/doc/install#install)
 or use your platform-of-choice's package manager. Or do the right
-thing, and build [Go from source](https://go.googlesource.com).
+thing, and build [Go from source](http://golang.org/doc/install/source).
 
 Just run:
 

--- a/ks/auth.go
+++ b/ks/auth.go
@@ -1,6 +1,7 @@
 // Copyright 2015 Yahoo
 // Author:  David Leon Gil (dgil@yahoo-inc.com)
 // License: Apache 2
+
 package ks
 
 import (

--- a/ks/cmd/ks/main.go
+++ b/ks/cmd/ks/main.go
@@ -1,6 +1,7 @@
 // Copyright 2015 Yahoo
 // Author:  David Leon Gil (dgil@yahoo-inc.com)
 // License: Apache 2
+
 package main
 
 import (

--- a/ks/config.go
+++ b/ks/config.go
@@ -1,6 +1,7 @@
 // Copyright 2015 Yahoo
 // Author:  David Leon Gil (dgil@yahoo-inc.com)
 // License: Apache 2
+
 package ks
 
 type config struct {

--- a/ks/doc.go
+++ b/ks/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2015 Yahoo
+// Author:  Dmitry Savintsev (dsavints@yahoo-inc.com)
+// License: Apache 2
+
+// Package ks implements a "keyshop" - a tiny keyserver stub (certificate authority)
+// provided for testing the E2E extension.
+package ks

--- a/ks/durable.go
+++ b/ks/durable.go
@@ -1,6 +1,7 @@
 // Copyright 2015 Yahoo
 // Author:  David Leon Gil (dgil@yahoo-inc.com)
 // License: Apache 2
+
 package ks
 
 import (

--- a/ks/handlers.go
+++ b/ks/handlers.go
@@ -1,6 +1,7 @@
 // Copyright 2015 Yahoo
 // Author:  David Leon Gil (dgil@yahoo-inc.com)
 // License: Apache 2
+
 package ks
 
 import (
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"encoding/json"
+
 	"github.com/golang/glog"
 	"github.com/gorilla/mux"
 	"github.com/yahoo/keyshop/yenc"

--- a/ks/init.go
+++ b/ks/init.go
@@ -1,6 +1,7 @@
 // Copyright 2015 Yahoo
 // Author:  David Leon Gil (dgil@yahoo-inc.com)
 // License: Apache 2
+
 package ks
 
 import (

--- a/ks/json.go
+++ b/ks/json.go
@@ -1,6 +1,7 @@
 // Copyright 2015 Yahoo
 // Author:  David Leon Gil (dgil@yahoo-inc.com)
 // License: Apache 2
+
 package ks
 
 // A DKey represents the key for a single device.

--- a/ks/kauth/kauth.go
+++ b/ks/kauth/kauth.go
@@ -1,6 +1,7 @@
 // Copyright 2015 Yahoo
 // Author:  David Leon Gil (dgil@yahoo-inc.com)
 // License: Apache 2
+
 package kauth
 
 import (

--- a/ks/logic.go
+++ b/ks/logic.go
@@ -1,6 +1,7 @@
 // Copyright 2015 Yahoo
 // Author:  David Leon Gil (dgil@yahoo-inc.com)
 // License: Apache 2
+
 package ks
 
 import (

--- a/yenc/yenc.go
+++ b/yenc/yenc.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Yahoo
 // Author:  David Leon Gil (dgil@yahoo-inc.com)
 // License: Apache 2
-//
+
 // Package yenc implements Yahoo-internal baseX encodings, as well
 // as some other specialized baseX encodings used at Yahoo.
 // (This variant is cleaned up for vendoring into Keyshop.)


### PR DESCRIPTION
Fixes current issues on http://godoc.org/github.com/yahoo/keyshop/ks (multiple copyright / author lines).  Added ks/doc.go to have a summary in the "Overview" on the godoc page (please modify if needed).
